### PR TITLE
Fix OpenShift container entrypoint

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -10,4 +10,4 @@ COPY --from=0 /go/src/github.com/kubernetes-csi/driver-registrar/driver-registra
 RUN useradd csi-attacher
 USER csi-attacher
 
-CMD ["/usr/bin/driver-registrar"]
+ENTRYPOINT ["/usr/bin/driver-registrar"]


### PR DESCRIPTION
I'ts now possible to run the image with "--v=5"