### PR TITLE
Don't run registrar under specific user

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -5,6 +5,4 @@ RUN go build ./cmd/driver-registrar
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/kubernetes-csi/driver-registrar/driver-registrar /usr/bin/
-RUN useradd csi-attacher
-USER csi-attacher
 ENTRYPOINT ["/usr/bin/driver-registrar"]

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -5,6 +5,4 @@ RUN go build ./cmd/driver-registrar
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/kubernetes-csi/driver-registrar/driver-registrar /usr/bin/
-RUN useradd csi-attacher
-USER csi-attacher
 ENTRYPOINT ["/usr/bin/driver-registrar"]


### PR DESCRIPTION
Let OpenShift default user handling apply. This fixes OpenShift running the container with UID 1000 instead of root in privileged containers.